### PR TITLE
Mobile: move 'Notifications' to the top (#389)

### DIFF
--- a/ui/scss/component/_navigation.scss
+++ b/ui/scss/component/_navigation.scss
@@ -25,9 +25,8 @@
   width: var(--side-nav-width);
   height: calc(100vh - var(--header-height));
   border-right: 1px solid var(--color-border);
-  padding-top: var(--spacing-l);
+  padding-top: var(--spacing-m);
   padding-bottom: var(--spacing-l);
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
 
@@ -39,6 +38,11 @@
       overflow-y: auto;
     }
   }
+
+  ul {
+    padding-bottom: var(--spacing-s);
+    border-bottom: 1px solid var(--color-border);
+  }
 }
 
 .navigation--mac {
@@ -49,9 +53,7 @@
   @extend .navigation;
   z-index: 4;
   width: var(--side-nav-width);
-  padding-top: 0;
   background-color: var(--color-card-background);
-  border-top: 1px solid var(--color-border);
   box-shadow: var(--card-box-shadow);
 
   .navigation-link {
@@ -216,7 +218,6 @@
 
 .navigation-links--absolute {
   @extend .navigation-links;
-  margin-top: 0;
 
   .navigation-link {
     margin-bottom: 0;


### PR DESCRIPTION
## Behavioral changes
- Moved Notifications to the top for mobile.
- Added separate lines between sections.

## Code changes
The array method is too restrictive (hard to move things with display logic around). It's also hard to read.

Instead of trying to populate an array, just directly populate the return tree. Added `getLink` to make things readable. It's now easier to see the sections in a glance.

## Fixes

Issue Number:

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

## What is the new behavior?

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
